### PR TITLE
Remove `app_name` property

### DIFF
--- a/schemas/spacefile/spacefile.v0.schema.json
+++ b/schemas/spacefile/spacefile.v0.schema.json
@@ -19,11 +19,6 @@
           "description": "Path to an icon image file (PNG or WebP file of 512x512 pixels)",
           "type": "string"
         },
-        "app_name": {
-          "description": "Display name of the app",
-          "type": "string",
-          "maxLength": 12
-        },
         "micros": {
           "description": "List of Micros in the app",
           "type": "array",


### PR DESCRIPTION
Remove `app_name` property from the Spacefile schema to let users know it will not be supported in the future.