### PR TITLE
don't allow both public and public_routes to be provided

### DIFF
--- a/schemas/spacefile/spacefile.v0.schema.json
+++ b/schemas/spacefile/spacefile.v0.schema.json
@@ -12,7 +12,9 @@
         "v": {
           "description": "Version number of the Spacefile",
           "type": "integer",
-          "enum": [0],
+          "enum": [
+            0
+          ],
           "default": 0
         },
         "icon": {
@@ -34,7 +36,10 @@
           }
         }
       },
-      "required": ["v", "micros"]
+      "required": [
+        "v",
+        "micros"
+      ]
     },
     "micro": {
       "title": "Micro",
@@ -133,7 +138,11 @@
           }
         }
       },
-      "required": ["name", "src", "engine"],
+      "required": [
+        "name",
+        "src",
+        "engine"
+      ],
       "allOf": [
         {
           "$comment": "If engine is static, then serve is required",
@@ -143,10 +152,23 @@
                 "const": "static"
               }
             },
-            "required": ["engine"]
+            "required": [
+              "engine"
+            ]
           },
           "then": {
-            "required": ["serve"]
+            "required": [
+              "serve"
+            ]
+          }
+        },
+        {
+          "$comment": "public and public_routes are mutually exclusive",
+          "not": {
+            "required": [
+              "public",
+              "public_routes"
+            ]
           }
         },
         {
@@ -154,19 +176,30 @@
           "if": {
             "properties": {
               "engine": {
-                "enum": ["static", "react", "vue", "svelte"]
+                "enum": [
+                  "static",
+                  "react",
+                  "vue",
+                  "svelte"
+                ]
               }
             },
-            "required": ["engine"]
+            "required": [
+              "engine"
+            ]
           },
           "then": {
             "not": {
-              "required": ["include"]
+              "required": [
+                "include"
+              ]
             }
           },
           "else": {
             "not": {
-              "required": ["serve"]
+              "required": [
+                "serve"
+              ]
             }
           }
         }
@@ -211,7 +244,9 @@
           "type": "string"
         }
       },
-      "required": ["name"]
+      "required": [
+        "name"
+      ]
     },
     "action": {
       "title": "Action",
@@ -235,7 +270,9 @@
         "trigger": {
           "description": "Trigger for the action",
           "type": "string",
-          "enum": ["schedule"],
+          "enum": [
+            "schedule"
+          ],
           "default": "schedule"
         },
         "default_interval": {
@@ -247,7 +284,12 @@
           "type": "string"
         }
       },
-      "required": ["id", "name", "trigger", "default_interval"]
+      "required": [
+        "id",
+        "name",
+        "trigger",
+        "default_interval"
+      ]
     }
   }
 }

--- a/tests/tests.ts
+++ b/tests/tests.ts
@@ -187,7 +187,26 @@ export const tests: Test[] = [
       ],
     },
   },
-
+  {
+    name: "public and public_routes at the same time",
+    description:
+      "Tests an invalid configuration with both 'public' and 'public_routes' properties",
+    valid: false,
+    schema: "spacefile",
+    version: 0,
+    data: {
+      v: 0,
+      micros: [
+        {
+          name: "static-micro",
+          src: ".",
+          engine: "python3.9",
+          public: true,
+          public_routes: ["public"],
+        },
+      ],
+    },
+  },
   // This test is currently not possible to validate because JSON Schema does not support unique item properties yet.
   // https://github.com/json-schema-org/json-schema-vocabularies/issues/22
 


### PR DESCRIPTION
Reasoning:

```
public: true
public_routes:
  - /route/index.html
```

is the same as:

```
public: true
```

and 

```
public: false
public_routes:
  - /route/index.html
```

is the same as

```
public_routes:
  - /route/index.html
```

Allowing both is confusing for the user, and is not handled well by our backend.